### PR TITLE
Use SHA256 as the default digest for openssl tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Changed
+- Explicitly use sha256 as the default digest for `openssl` invoke tasks
+  - Note: This is a backwards-incompatible change and may require re-encrypting files depending on the version of openssl being used
 - Switched CI from Travis to Github Actions
 
 ## [0.3.1]

--- a/opstrich/invoke/openssl.py
+++ b/opstrich/invoke/openssl.py
@@ -7,7 +7,7 @@ def encrypt(c, filename):
     Generate an encrypted version of the file using OpenSSL.
     """
     c.run(
-        f"openssl aes-256-cbc -k $DECRYPT_PASSWORD -in {filename} -out {filename}.enc"
+        f'openssl aes-256-cbc -md sha256 -k "$DECRYPT_PASSWORD" -in {filename} -out {filename}.enc'
     )
 
 
@@ -17,5 +17,5 @@ def decrypt(c, filename):
     Generate an decrypted version of the file using OpenSSL.
     """
     c.run(
-        f"openssl aes-256-cbc -k $DECRYPT_PASSWORD -in {filename}.enc -out {filename} -d"
+        f'openssl aes-256-cbc -md sha256 -k "$DECRYPT_PASSWORD" -in {filename}.enc -out {filename} -d'
     )


### PR DESCRIPTION
This resolves ambiguity across openssl versions which can have different default digests.

Unfortunately, this change could result in users being unable to decrypt files that were previously encrypted with the openssl tasks. To get around this, users should re-encrypt their files with SHA256 as the default digest.